### PR TITLE
fix(backend): Bump PyJWT 2.10.1 -> 2.12.0 (CVE-2026-32597)

### DIFF
--- a/terraviva/backend/requirements/base.txt
+++ b/terraviva/backend/requirements/base.txt
@@ -46,7 +46,7 @@ pydantic==2.12.5
 pydantic_core==2.41.5
 Pygments==2.19.2
 pyiceberg==0.10.0
-PyJWT==2.10.1
+PyJWT==2.12.0
 pyparsing==3.3.1
 pyroaring==1.0.3
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Bumps PyJWT to 2.12.0, which adds validation for the `crit` (Critical) header parameter per RFC 7515 §4.1.11. Resolves Dependabot alert #173.