### PR TITLE
Release: Sync develop into main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,17 @@ updates:
           - "minor"
           - "patch"
 
+  # Docker base images (frontend and backend)
+  - package-ecosystem: "docker"
+    directories:
+      - "/terraviva/frontend"
+      - "/terraviva/backend"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(docker)"
+      include: "scope"
+
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Promotes the latest develop changes to main:
  
- chore(ci): Add Docker ecosystem to Dependabot configuration (#40)

All checks passed on develop.