### PR TITLE
refactor(storage): Migrate SupabaseStorage from supabase to storage3

### DIFF
--- a/terraviva/backend/config/storage.py
+++ b/terraviva/backend/config/storage.py
@@ -3,14 +3,14 @@
 from django.conf import settings
 from django.core.files.base import ContentFile, File
 from django.core.files.storage import Storage
-from supabase import create_client
+from storage3 import create_client
 
 
 class SupabaseStorage(Storage):
     """Django storage backend for Supabase Storage."""
 
     def __init__(self) -> None:
-        """Initialize Supabase client."""
+        """Initialize Supabase storage client."""
         self.supabase_url = getattr(settings, "SUPABASE_URL", "")
         self.supabase_key = getattr(settings, "SUPABASE_SERVICE_KEY", "")
         self.bucket_name = getattr(settings, "SUPABASE_STORAGE_BUCKET", "media")
@@ -18,7 +18,14 @@ class SupabaseStorage(Storage):
         if not self.supabase_url or not self.supabase_key:
             raise ValueError("SUPABASE_URL and SUPABASE_SERVICE_KEY must be set")
 
-        self.client = create_client(self.supabase_url, self.supabase_key)
+        # storage3 expects the storage API URL and explicit auth headers,
+        # rather than the project URL plus a key. Build them once.
+        storage_url = f"{self.supabase_url}/storage/v1"
+        headers = {
+            "apiKey": self.supabase_key,
+            "Authorization": f"Bearer {self.supabase_key}",
+        }
+        self.client = create_client(storage_url, headers, is_async=False)
 
     def _get_public_url(self, name: str) -> str:
         """Get public URL for a file."""
@@ -27,7 +34,6 @@ class SupabaseStorage(Storage):
     def _get_content_type(self, content: File) -> str:
         """Determine content type from file."""
         content_type = getattr(content, "content_type", "application/octet-stream")
-
         filename = getattr(content, "name", None)
         if filename:
             filename_lower = filename.lower()
@@ -39,36 +45,32 @@ class SupabaseStorage(Storage):
                 content_type = "image/gif"
             elif filename_lower.endswith(".webp"):
                 content_type = "image/webp"
-
         return content_type
 
     def _save(self, name: str, content: File) -> str:
         """Save file to Supabase Storage."""
         file_content = content.read()
         content_type = self._get_content_type(content)
-
-        # Upload to Supabase
-        self.client.storage.from_(self.bucket_name).upload(
+        self.client.from_(self.bucket_name).upload(
             path=name,
             file=file_content,
             file_options={"content-type": content_type, "upsert": "true"},
         )
-
         return name
 
     def _open(self, name: str, mode: str = "rb") -> ContentFile:
         """Open file from Supabase Storage."""
-        response = self.client.storage.from_(self.bucket_name).download(name)
+        response = self.client.from_(self.bucket_name).download(name)
         return ContentFile(response)
 
     def delete(self, name: str) -> None:
         """Delete file from Supabase Storage."""
-        self.client.storage.from_(self.bucket_name).remove([name])
+        self.client.from_(self.bucket_name).remove([name])
 
     def exists(self, name: str) -> bool:
         """Check if file exists in Supabase Storage."""
         try:
-            self.client.storage.from_(self.bucket_name).download(name)
+            self.client.from_(self.bucket_name).download(name)
             return True
         except Exception:
             return False
@@ -81,5 +83,5 @@ class SupabaseStorage(Storage):
 
     def size(self, name: str) -> int:
         """Get file size."""
-        response = self.client.storage.from_(self.bucket_name).download(name)
+        response = self.client.from_(self.bucket_name).download(name)
         return len(response)

--- a/terraviva/backend/requirements/base.txt
+++ b/terraviva/backend/requirements/base.txt
@@ -38,7 +38,6 @@ multidict==6.7.1
 oauthlib==3.3.1
 packaging==26.1
 pillow==12.2.0
-postgrest==2.28.3
 propcache==0.4.1
 psycopg2-binary==2.9.11
 pycparser==3.0
@@ -52,7 +51,6 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 python3-openid==3.2.0
 pytz==2026.1.post1
-realtime==2.28.3
 requests==2.33.1
 requests-oauthlib==2.0.0
 rich==14.3.4
@@ -65,15 +63,11 @@ storage3==2.28.3
 StrEnum==0.4.15
 strictyaml==1.7.3
 stripe==15.0.1
-supabase==2.28.3
-supabase-auth==2.28.3
-supabase-functions==2.28.3
 tenacity==9.1.4
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 uritemplate==4.2.0
 urllib3==2.6.3
-websockets==15.0.1
 whitenoise==6.12.0
 yarl==1.23.0
 pyopenssl==26.0.0


### PR DESCRIPTION
## Context

Dependabot PR #60 broke trying to bump `websockets` 15.0.1 → 16.0:

```
realtime 2.29.0 depends on websockets<16 and >=11
```

`websockets` was a transitive dependency via `supabase` → `realtime`. The latest `realtime` version (2.29.0) still requires `websockets<16`, and the Realtime/Auth/Functions/Postgrest APIs of the umbrella package were never used in the project.

## Solution

Migrate `SupabaseStorage` to use `storage3` directly, eliminating the umbrella package and its satellite dependencies:

- `from supabase import create_client` → `from storage3 import create_client`
- `client.storage.from_(bucket)` → `client.from_(bucket)`
- URL and authentication headers built explicitly

Removed from `requirements/base.txt`: `supabase`, `supabase-auth`, `supabase-functions`, `postgrest`, `realtime`, `websockets`.

`storage3` still pulls `pyiceberg`, so the `cachetools` and `rich` ignores in `dependabot.yml` remain necessary and valid.

## Validation

- Local `pytest` with clean venv: 30/30 passing
- CI (Backend Lint + Backend Test) should pass without the `websockets` conflict

## Next steps

After merging, close PR #60 referencing this one.