### PR TITLE
fix(deps): Bump Node base image to 24-alpine (LTS)

### DIFF
--- a/terraviva/frontend/Dockerfile
+++ b/terraviva/frontend/Dockerfile
@@ -9,7 +9,7 @@
 # Stage 1: Builder
 # Build the Vue.js application with Vite
 # -----------------------------------------------------------------------------
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Context

Node 20 reached EOL on April 30, 2026, so the frontend Dockerfile builder stage needs to be bumped. Dependabot proposed Node 26-alpine in #79, but Node 26 was released on May 5, 2026 as a Current release and only enters Active LTS in October 2026. Per Node.js official guidance, Current releases are intended for development and testing rather than production builds.

## Changes

`terraviva/frontend/Dockerfile`: builder stage bumped from `node:20-alpine` to `node:24-alpine` (Active LTS, supported until April 30, 2028).

## Notes

The Dockerfile is multi-stage. The final image runs `nginx:alpine` and contains no Node runtime, so the Node version only affects the build environment (`npm ci` + `npm run build`). Vercel deployments use the buildpack and ignore the Dockerfile entirely.

Replaces #79.