### PR TITLE
fix(deps): Bump idna to 3.16 and unpin pydantic_core for CVE-2026-45409

### DIFF
--- a/terraviva/backend/requirements/base.txt
+++ b/terraviva/backend/requirements/base.txt
@@ -27,7 +27,7 @@ hpack==4.1.0
 httpcore==1.0.9
 httpx==0.28.1
 hyperframe==6.1.0
-idna==3.13
+idna==3.16
 itypes==1.2.0
 Jinja2==3.1.6
 markdown-it-py==4.0.0
@@ -42,7 +42,6 @@ propcache==0.4.1
 psycopg2-binary==2.9.12
 pycparser==3.0
 pydantic==2.13.3
-pydantic_core==2.46.3
 Pygments==2.20.0
 PyJWT==2.12.1
 pyparsing==3.3.2


### PR DESCRIPTION
## Security hotfix

Closes Dependabot alert #229 (CVE-2026-45409, idna < 3.15).

### Changes
- `idna` 3.13 -> 3.16 (patches IDNA encode bypass of CVE-2024-3651 fix)
- Remove explicit `pydantic_core==2.46.3` pin

### Why unpin pydantic_core
`pydantic_core` is a transitive dependency of `pydantic`, which pins the exact compatible core version. The explicit pin (likely from a `pip freeze`) caused Dependabot to bump them independently, producing a `ResolutionImpossible` conflict in PR #91 (`pydantic 2.13.4` requires `pydantic-core==2.46.4`, not `2.47.0`). Removing the pin lets `pydantic` resolve its own core and prevents the conflict from recurring.

### Follow-up
- Back-merge into `develop`
- Close #91 (superseded; remaining 13 minor-patch bumps will be regenerated cleanly)