### PR TITLE
chore(ci): Add Dependabot cooldown and target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
 # Dependabot configuration
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   # Frontend (Vite + Vue) - npm
   - package-ecosystem: "npm"
     directory: "/terraviva/frontend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -14,15 +14,20 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       frontend-minor-patch:
         update-types:
           - "minor"
           - "patch"
-
   # Backend (Django) - pip via requirements
   - package-ecosystem: "pip"
     directory: "/terraviva/backend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -31,6 +36,11 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       backend-minor-patch:
         update-types:
@@ -44,12 +54,12 @@ updates:
       # Bloqueado por pyiceberg (dep transitiva de supabase-storage3) que requer rich<15
       - dependency-name: "rich"
         versions: [">=15.0.0"]
-
   # Docker base images
   - package-ecosystem: "docker"
     directories:
       - "/terraviva/frontend"
       - "/terraviva/backend"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:
@@ -57,10 +67,15 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:
@@ -68,3 +83,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30


### PR DESCRIPTION
## Supply-chain hardening

Adds a `cooldown` block to all four update configs (npm, pip, docker, github-actions) and routes version-update PRs to the `develop` branch via `target-branch`.

### Cooldown values
- `default-days`: 7 (floor for anything outside semver categories)
- `semver-patch-days`: 7
- `semver-minor-days`: 14
- `semver-major-days`: 30

### Rationale
Most supply-chain compromises (malicious publish, compromised maintainer account) are detected and yanked within hours to a few days. Aging releases before adoption shrinks exposure to that window. Majors wait longest (30d) for carrying both breaking-change and higher supply-chain risk; patches wait 7d to stay responsive.

### target-branch
Version-update PRs now target `develop` (integration), aligned with Gitflow, instead of the default `main`. The `dependabot.yml` file itself stays on `main`, since Dependabot always reads its config from the default branch.

### Preserved
- Existing `ignore` rules for `cachetools` (<7) and `rich` (<15), blocked by pyiceberg transitive constraint
- Docker `directories` (plural) covering frontend and backend

### Scope
Cooldown applies only to version updates; security updates remain immediate. Note: `target-branch` redirects version updates only — security updates follow default behavior.