### PR TITLE
fix(deps): Bump social-auth-core and social-auth-app-django majors together

### DIFF
--- a/terraviva/backend/requirements/base.txt
+++ b/terraviva/backend/requirements/base.txt
@@ -54,8 +54,8 @@ requests==2.34.2
 requests-oauthlib==2.0.0
 rich==14.3.4
 six==1.17.0
-social-auth-app-django==5.9.0
-social-auth-core==4.9.1
+social-auth-app-django==6.0.0
+social-auth-core==5.0.2
 sortedcontainers==2.4.0
 sqlparse==0.5.5
 storage3==2.31.0


### PR DESCRIPTION
Raises both social-auth packages in one change. They are a coupled pair: social-auth-app-django 6.0.0 requires social-auth-core >=5.0.0, while 5.9.0 required <5.0.0. Dependabot split them into #109 and #110, each bumping only one side, which fails pip resolution (ResolutionImpossible).

- social-auth-core 4.9.1 -> 5.0.2
- social-auth-app-django 5.9.0 -> 6.0.0

Supersedes #109 and #110, which should be closed once this lands.